### PR TITLE
Add link tag in htmlpair (must be closed)

### DIFF
--- a/wikimarkup/parser.py
+++ b/wikimarkup/parser.py
@@ -44,7 +44,7 @@ _htmlpairs = ( # Tags that must be closed
     u'h2', u'h3', u'h4', u'h5', u'h6', u'cite', u'code', u'em', u's',
     u'strike', u'strong', u'tt', u'var', u'div', u'center',
     u'blockquote', u'ol', u'ul', u'dl', u'table', u'caption', u'pre',
-    u'ruby', u'rt' , u'rb' , u'rp', u'p', u'span', u'u',
+    u'ruby', u'rt' , u'rb' , u'rp', u'p', u'span', u'u', u'a',
 )
 _htmlsingle = (
     u'br', u'hr', u'li', u'dt', u'dd', u'img',


### PR DESCRIPTION
Link tag ("a") must be closed because change to ">" to html entities.

Example:

```python
text = '<a href="/hello-world">Hello World </a> and  [/thanks-wikimarkup thanks wikimarkup]'
```

Render:

```html
<p>&lt;a href="/hello-world"&gt;Hello World &lt;/a&gt; and  <a href="/thanks-wikimarkup">thanks wikimarkup</a></p>
```
With this PR, render will be:

```html
<p><a>Hello World </a> and  <a href="/thanks-wikimarkup">thanks wikimarkup</a></p>
```